### PR TITLE
fix: Detect target features instead of host features

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 fn main() {
-    if is_x86_feature_detected!("sse4.1") || is_x86_feature_detected!("sse2") {
+    // Some target(e.g. wasm32-unknown-unknown) won't have this flag
+    // defined since it has not features.
+    let features = std::env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+    if features.contains("sse4.1") || features.contains("sse2") {
         cc::Build::new()
             .file("BLAKE2/sse/blake2b.c")
             .compile("libblake2b.a");


### PR DESCRIPTION
Current code actually detects features on the host, not the
target. While this works since we are only compiling on x86_64 for
x86_64, it will run into problems when we are trying to cross-compile
this crate for other targets, such as wasm. This commit fixes the problem.