### PR TITLE
feat: CKB contract changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,12 +2,21 @@ fn main() {
     // Some target(e.g. wasm32-unknown-unknown) won't have this flag
     // defined since it has not features.
     let features = std::env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     if features.contains("sse4.1") || features.contains("sse2") {
         cc::Build::new()
             .file("BLAKE2/sse/blake2b.c")
             .compile("libblake2b.a");
     } else {
-        cc::Build::new()
+        let mut build = cc::Build::new();
+        if target_arch == "riscv64" {
+            // Blake2b only requires a small part of libc, e.g., stdint.h for
+            // common type definitions, as well as prototypes for memory related
+            // functions. It's thus fine to use libc headers from picolibc as
+            // stubs here.
+            build.include("/usr/lib/picolibc/riscv64-unknown-elf/include");
+        }
+        build
             .file("BLAKE2/ref/blake2b-ref.c")
             .compile("libblake2b.a");
     }

--- a/src/binding_layout_tests.rs
+++ b/src/binding_layout_tests.rs
@@ -199,7 +199,9 @@ fn bindgen_test_layout_blake2b_param__() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<blake2b_param__>())).leaf_length as *const _ as usize },
+        unsafe {
+            core::ptr::addr_of!((*(::core::ptr::null::<blake2b_param__>())).leaf_length) as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -209,7 +211,9 @@ fn bindgen_test_layout_blake2b_param__() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<blake2b_param__>())).node_offset as *const _ as usize },
+        unsafe {
+            core::ptr::addr_of!((*(::core::ptr::null::<blake2b_param__>())).node_offset) as usize
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -219,7 +223,9 @@ fn bindgen_test_layout_blake2b_param__() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<blake2b_param__>())).xof_length as *const _ as usize },
+        unsafe {
+            core::ptr::addr_of!((*(::core::ptr::null::<blake2b_param__>())).xof_length) as usize
+        },
         12usize,
         concat!(
             "Offset of field: ",


### PR DESCRIPTION
This PR started out as a simple fix on libc headers, but grow to contain more changes suitable for CKB smart contract usages.